### PR TITLE
Add ability to poll for ZC events

### DIFF
--- a/src/PSM.cpp
+++ b/src/PSM.cpp
@@ -21,6 +21,7 @@ PSM::PSM(unsigned char sensePin, unsigned char controlPin, unsigned int range, i
 
   PSM::_range = range;
   PSM::_interruptMinTimeDiff = interruptMinTimeDiff;
+  PSM::_zcCrossed = false;
 }
 
 void onPSMInterrupt() __attribute__((weak));
@@ -38,6 +39,7 @@ void PSM::onZCInterrupt(void) {
   onPSMInterrupt();
 
   _thePSM->calculateSkipFromZC();
+  _thePSM->_zcCrossed = true;
 
   if (_thePSM->_psmIntervalTimerInitialized) {
     _thePSM->_psmIntervalTimer->setCount(0);
@@ -159,6 +161,12 @@ void PSM::setDivider(unsigned char divider) {
 
 void PSM::shiftDividerCounter(char value) {
   PSM::_dividerCounter += value;
+}
+
+bool PSM::hasZC() {
+  bool crossed = _zcCrossed;
+  _zcCrossed = false;
+  return crossed;
 }
 
 void PSM::initTimer(uint16_t delay, TIM_TypeDef* timerInstance) {

--- a/src/PSM.h
+++ b/src/PSM.h
@@ -23,6 +23,7 @@ public:
   unsigned char getDivider(void);
   void setDivider(unsigned char divider = 1);
   void shiftDividerCounter(char value = 1);
+  bool hasZC(void);
 
 private:
   static inline void onZCInterrupt(void);
@@ -40,6 +41,7 @@ private:
   volatile unsigned int _value;
   volatile unsigned int _a;
   volatile bool _skip = true;
+  volatile bool _zcCrossed;
   volatile long _counter;
   volatile long _stopAfter;
   volatile unsigned long _lastMillis = 0;


### PR DESCRIPTION
This aims to add a ZC poll function to use it as a utility function in other cases where switching the load at ZC would aid negate any of the back emi effects of switching the load anywhere else might introduce.